### PR TITLE
Allow conversion from relative line ranges to absolute char ranges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,8 +598,6 @@ impl TextFile {
     pub fn line_to_bytes(&self, line: isize) -> Result<usize, Error> {
         if self.positionindex.lines.len() == 0 {
             Err(Error::NoLineIndex)
-        } else if line as usize == self.positionindex.lines.len() {
-            Ok(self.positionindex.bytesize)
         } else if line < 0 {
             if line.abs() as usize > self.positionindex.lines.len() {
                 Err(Error::OutOfBoundsError {
@@ -609,6 +607,8 @@ impl TextFile {
             } else {
                 self.line_to_bytes(self.positionindex.lines.len() as isize - line.abs())
             }
+        } else if line as usize == self.positionindex.lines.len() {
+            Ok(self.positionindex.bytesize)
         } else {
             if let Some(begin) = self.positionindex.lines.get(line as usize) {
                 Ok(begin)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,36 +640,20 @@ impl TextFile {
     ///
     /// * `begin` - The begin offset in unicode character points (0-indexed). If negative, it is interpreted relative to the end of the text.
     /// * `end` - The end offset in unicode character points (0-indexed, non-inclusive). If 0 or negative, it is interpreted relative to the end of the text.
-    pub fn absolute_pos(&self, begin: isize, end: isize) -> Result<(usize, usize), Error> {
-        if begin >= 0 && end > 0 && begin < end {
-            Ok((begin as usize, end as usize))
-        } else if begin >= 0 && end <= 0 && end.abs() as usize <= self.positionindex.charsize {
-            Ok((begin as usize, self.positionindex.charsize + end as usize))
-        } else if begin < 0 && end > 0 && begin.abs() as usize <= self.positionindex.charsize {
-            let begin_abs = self.positionindex.charsize - begin.abs() as usize;
-            if begin_abs > end as usize {
-                return Err(Error::OutOfBoundsError { begin, end });
-            }
-            Ok((begin_abs, end as usize))
-        } else if begin < 0
-            && end <= 0
-            && end.abs() as usize <= self.positionindex.charsize
-            && begin.abs() as usize <= self.positionindex.charsize
-            && begin.abs() > end.abs()
-        {
-            let begin_abs = self.positionindex.charsize - begin.abs() as usize;
-            let end_abs = self.positionindex.charsize - end.abs() as usize;
-            if begin_abs > end_abs {
-                return Err(Error::OutOfBoundsError { begin, end });
-            }
-            Ok((begin_abs, end_abs))
-        } else {
-            //shouldn't occur
-            unreachable!(
-                "Out of Bounds with {}-{}, should never happen (logic error)",
-                begin, end
-            )
+    pub fn absolute_pos(&self, mut begin: isize, mut end: isize) -> Result<(usize, usize), Error> {
+        if begin < 0 {
+            begin += self.positionindex.charsize as isize;
         }
+
+        if end <= 0 {
+            end += self.positionindex.charsize as isize;
+        }
+
+        if begin < 0 || end < 0 || begin > end {
+            return Err(Error::OutOfBoundsError { begin, end });
+        }
+
+        Ok((begin as usize, end as usize))
     }
 
     /// Returns the length of the total text file in characters, i.e. the number of character in the text


### PR DESCRIPTION
This PR is related to [this PR adding streamed responses to textsurf](https://github.com/knaw-huc/textsurf/pull/6).

It adds functionality for converting relative line ranges to absolute character ranges.

This enables textsurf to split a line-based query into equal-sized chunks, and send the response as a steam.

Should be merged after #2 if possible